### PR TITLE
cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,5 @@
 resolver = "2"
 members = ["common", "browser"]
 
-[profile.release.target.wasm32-unknown-unknown]
+[profile.release.package.browser]
 opt-level = "s"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+ba = "ba" # as in merge_ab/merge_ba

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod hlc;
 pub mod lww;
 pub mod lww_map;
+
+#[cfg(test)]
+mod test_utils;

--- a/common/src/lww.rs
+++ b/common/src/lww.rs
@@ -23,7 +23,7 @@ impl<T> Lww<T> {
 
     pub fn merge(mut self, other: Lww<T>) -> Self {
         self.set(other.value, other.clock);
-        return self;
+        self
     }
 
     pub fn value(&self) -> &T {

--- a/common/src/lww_map.rs
+++ b/common/src/lww_map.rs
@@ -24,8 +24,8 @@ where
         match self.inner.entry(key) {
             Entry::Occupied(entry) => {
                 let (key, existing) = entry.remove_entry();
-                let new = existing.merge(value);
-                self.inner.insert(key, new);
+                let next = existing.merge(value);
+                self.inner.insert(key, next);
             }
             Entry::Vacant(entry) => {
                 entry.insert(value);

--- a/common/src/lww_map.rs
+++ b/common/src/lww_map.rs
@@ -22,8 +22,10 @@ where
 
     pub fn insert(&mut self, key: K, value: Lww<V>) {
         match self.inner.entry(key) {
-            Entry::Occupied(mut entry) => {
-                entry.get_mut().merge(value);
+            Entry::Occupied(entry) => {
+                let (key, existing) = entry.remove_entry();
+                let new = existing.merge(value);
+                self.inner.insert(key, new);
             }
             Entry::Vacant(entry) => {
                 entry.insert(value);

--- a/common/src/lww_map.rs
+++ b/common/src/lww_map.rs
@@ -60,8 +60,8 @@ mod test {
     }
 
     mod set {
-        use chrono::{TimeZone, Utc};
-        use proptest::{prop_assert_eq, prop_compose, proptest};
+        use crate::test_utils::clock;
+        use proptest::{prop_assert_eq, proptest};
 
         use super::*;
 
@@ -71,16 +71,6 @@ mod test {
             map.insert("test", Lww::new(1, Hlc::new(Uuid::nil())));
 
             assert_eq!(map.get(&"test").unwrap().value(), &1);
-        }
-
-        prop_compose! {
-            fn clock()
-                (uuid: u128, timestamp in 0i64..2_000_000_000i64) -> Hlc {
-                Hlc::new_at(
-                    Uuid::from_u128(uuid),
-                    Utc.timestamp_opt(timestamp, 0).unwrap(),
-                )
-            }
         }
 
         proptest! {

--- a/common/src/lww_map.rs
+++ b/common/src/lww_map.rs
@@ -85,7 +85,7 @@ mod test {
 
         proptest! {
             #[test]
-            fn insert_(
+            fn insert_follows_merge_precedence_rules(
                 c1 in clock(),
                 c2 in clock(),
             ) {

--- a/common/src/test_utils.rs
+++ b/common/src/test_utils.rs
@@ -1,0 +1,14 @@
+use crate::hlc::Hlc;
+use chrono::{TimeZone, Utc};
+use proptest::prop_compose;
+use uuid::Uuid;
+
+prop_compose! {
+    pub fn clock()
+        (uuid: u128, timestamp in 0i64..2_000_000_000i64) -> Hlc {
+        Hlc::new_at(
+            Uuid::from_u128(uuid),
+            Utc.timestamp_opt(timestamp, 0).unwrap(),
+        )
+    }
+}


### PR DESCRIPTION
- **fill in test name, oops**
- **move clock composition to somewhere shared**
- **test merge rules**
- **use "next" consistently**
- **make this a property test instead of reimplementing**
- **mark "ba" as acceptable**
- **accept clippy fix**
- **add a WASM size report**
- **apply opt-level properly**
